### PR TITLE
Add frame ancestors to the next config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,34 @@ const envHost = JSON.stringify(process.env.HOST);
 const host = process.env.HOST;
 
 module.exports = {
+      async headers() {
+      return [
+        {
+          source: "/(.*?)",
+          headers: [
+            {
+              key: "Content-Security-Policy",
+              value: "frame-ancestors 'self' https://*.myshopify.com",
+            },
+          ],
+        },
+        {
+          source: "/(.*?)",
+          has: [
+            {
+              type: "query",
+              key: "shop",
+            },
+          ],
+          headers: [
+            {
+              key: "Content-Security-Policy",
+              value: "frame-ancestors 'self' https://admin.shopify.com https://:shop;",
+            },
+          ],
+        },
+      ];
+    },
   webpack: (config) => {
     const env = { API_KEY: apiKey, HOST: envHost };
     config.plugins.push(new webpack.DefinePlugin(env));


### PR DESCRIPTION
When publishing to shopify there is a requirement to protect the [iframe](https://shopify.dev/apps/store/security/iframe-protection) by setting the frame ancestors.
This config is discussed in this [slack thread](https://shopifypartners.slack.com/archives/C4E5GV5U4/p1628099641042700)