### PR TITLE
Add full URL to Next config to work with Heroku deployment

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -51,7 +51,7 @@ module.exports = {
     return [
       {
         source: "/api/:path*",
-        destination: `${host}/api/:path*`,
+        destination: `https://www.${host}/api/:path*`,
       },
     ];
   },


### PR DESCRIPTION
Fix for this error when deploying to Heroku:

`destination` does not start with `/`, `http://`, or `https://` for route {"source":"/api/:path*","destination":"${host}/api/:path*"}